### PR TITLE
Update HC_Boneworking.txt

### DIFF
--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Boneworking.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Boneworking.txt
@@ -328,14 +328,16 @@ item HCDicebone
 		DisplayCategory          =   Toy,
     } 
 
-item HCBoneneedle
-    {
-        Weight    		= 0.1,
-        Type    		= Normal,
-        DisplayName         	= Bone Needle,
-        icon 			= HCBoneneedle,
-		DisplayCategory          =   CraftTailor,
-    } 
+	/*Tag added so this item now works with [Recipe.GetItemTypes.SewingNeedle] - Hugo*/
+	item HCBoneneedle
+	{
+		Weight		= 0.1,
+		Type		= Normal,
+		DisplayName	= Bone Needle,
+		icon		= HCBoneneedle,
+		DisplayCategory	= CraftTailor,
+		Tags		= SewingNeedle,
+	}
 
 
  item HCGluejar


### PR DESCRIPTION
SewingNeedle added to HCBoneBeedle, so the item now works with the [Recipe.GetItemTypes.SewingNeedle] function.

Next step is to replace all the Needle/HCBoneNeedle lines in numerous recipes.