### PR TITLE
Update HC_Floors.txt

### DIFF
--- a/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Floors.txt
+++ b/Contents/mods/Hydrocraft/media/scripts/Hydrocraft/HC_Floors.txt
@@ -3,7 +3,6 @@ module Hydrocraft
     imports
     {
         Base, Radio
-
     }
 
 /************************ITEMS************************/
@@ -18,89 +17,7 @@ item HCFinewoodfloor
 	DisplayCategory          =   Tile,
 	}
 
-item HCCarpetpurple
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_6,
-	DisplayName		= Violet Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetblue
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_0,
-	DisplayName		= Blue Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetgreen
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_5,
-	DisplayName		= Green Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetyellow
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_10,
-	DisplayName		= Yellow Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetorange
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_12,
-	DisplayName		= Orange Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetred
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_9,
-	DisplayName		= Red Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetwhite
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_11,
-	DisplayName		= White Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-item HCCarpetblack
-	{
-	Type 			= Moveable,
-	Weight 			= 0.5,
-	WorldObjectSprite 	= floors_interior_carpet_01_2,
-	DisplayName		= Black Carpet,
-	Icon			= default,
-	DisplayCategory          =   Tile,
-	}
-
-
-
-item HCNewfloor
+/*item HCNewfloor
     {
     Type            = Moveable,
     Weight          = 0.5,
@@ -108,9 +25,7 @@ item HCNewfloor
     DisplayName     = Black Carpet,
     Icon            = default,
 	DisplayCategory          =   Tile,
-    }
-
-
+    }*/
 
 /************************RECIPES************************/
 
@@ -143,126 +58,6 @@ recipe Make Finewood Floor
     	Time:1000,
     	Category:Carpentry,
         OnGiveXP:HCWoodwork_OnGiveXP,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarnpurple=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetpurple,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarnblue=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetblue,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarngreen=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetgreen,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarnyellow=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetyellow,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarnorange=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetorange,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarnred=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetred,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarn=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetwhite,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
-    }
-
-recipe Make Carpet
-    {
-   	HCYarnblack=3,
-	HCWoolcloth,
-   	keep Needle/HCBoneneedle,
-    	Thread=3,
-    	keep HCLoomfloor,
-    	Result:HCCarpetblack,
-    	CanBeDoneFromFloor:true,
-    	Time:1000,
-    	Category:Weaving,
-    	OnCreate:recipe_hcspindle3,
-    	OnGiveXP:Recipe.OnGiveXP.None,
     }
 	
 }


### PR DESCRIPTION
Carpet items & recipes removed, new recipes using vanilla carpets added in HC_Floors_Carpet.txt

If we want to make tiled floors craftable there are 41 indoor tiles & 8 outdoor tiles.  Not sure the outdoor tiles will work, as they can't be picked up in vanilla - we might be able to change that though, not 100% sure.