### PR TITLE
Update Recipe_GetItemTypes.lua

### DIFF
--- a/Contents/mods/Hydrocraft/media/lua/server/Recipe_GetItemTypes.lua
+++ b/Contents/mods/Hydrocraft/media/lua/server/Recipe_GetItemTypes.lua
@@ -72,3 +72,8 @@ end
 function Recipe.GetItemTypes.FishHooks(scriptItems)
 	scriptItems:addAll(getScriptManager():getItemsTag("FishHook"))
 end
+
+--any item that can be used to 'Take Dirt' (shovels & trowel in vanilla + modded items)
+function Recipe.GetItemTypes.TakeDirt(scriptItems)
+	scriptItems:addAll(getScriptManager():getItemsTag("TakeDirt"))
+end


### PR DESCRIPTION
GetItemTypes function for any item that can be used to 'Take Dirt' (shovels & trowel in vanilla + modded items, as long as they are correctly tagged)